### PR TITLE
feat: rename FileNameFormatStr to 2006-01-02-15-04

### DIFF
--- a/util/file_name_util.go
+++ b/util/file_name_util.go
@@ -6,13 +6,13 @@ import (
 	"time"
 )
 
-const FileNameFormatStr = "2006-01-02_15_04"
+const FileNameFormatStr = "2006-01-02-15-04"
 
 // FileNameBeforeDays 查找文件名中有多少在指定天数之前的
 func FileNameBeforeDays(days int, fileNames []string) []string {
 	oldFiles := make([]string, 0)
-	// 2006-01-02_15_04
-	fileRegxp := regexp.MustCompile(`([\d]{4})-([\d]{2})-([\d]{2})_([\d]{2})_([\d]{2})`)
+	// 2006-01-02-15-04
+	fileRegxp := regexp.MustCompile(`([\d]{4})-([\d]{2})-([\d]{2})-([\d]{2})-([\d]{2})`)
 	subDuration, _ := time.ParseDuration("-" + strconv.Itoa(days*24) + "h")
 	before := time.Now().Add(subDuration)
 	for i := 0; i < len(fileNames); i++ {

--- a/util/file_name_util_test.go
+++ b/util/file_name_util_test.go
@@ -11,8 +11,8 @@ func TestFileNameUtil(t *testing.T) {
 	const days = 10
 	beforeTomorrow, _ := time.ParseDuration("-" + strconv.Itoa((days+1)*24) + "h")
 	fileNames := []string{
-		"a2020-10-10_11_12b.sql",
-		"测试2021-10-10_11_12测试.sql",
+		"a2020-10-10-11-12b.sql",
+		"测试2021-10-10-11-12测试.sql",
 		time.Now().Add(beforeTomorrow).Format(FileNameFormatStr) + ".sql",
 	}
 	if len(fileNames) != len(FileNameBeforeDays(10, fileNames)) {


### PR DESCRIPTION
修复某些情况下，在对象存储中不能直接下载文件。
如果升级到此补丁，之前的备份需要手动删除