### PR TITLE
feat: 对象存储新增 Region 配置

### DIFF
--- a/entity/s3_config.go
+++ b/entity/s3_config.go
@@ -20,6 +20,7 @@ type S3Config struct {
 	AccessKey  string
 	SecretKey  string
 	BucketName string
+	Region     string
 }
 
 var ErrS3Empty = errors.New("s3 config is empty")
@@ -51,7 +52,10 @@ func (s3Config S3Config) getSession() (*session.Session, error) {
 	}
 
 	region := "cn-north-1"
-	if strings.HasSuffix(s3Config.Endpoint, "amazonaws.com") {
+	// 优先使用配置的Region
+	if s3Config.Region != "" {
+		region = s3Config.Region
+	} else if strings.HasSuffix(s3Config.Endpoint, "amazonaws.com") {
 		sp := strings.Split(s3Config.Endpoint, ".")
 		if len(sp) > 1 {
 			region = sp[1]

--- a/web/save.go
+++ b/web/save.go
@@ -102,6 +102,7 @@ func Save(writer http.ResponseWriter, request *http.Request) {
 	conf.AccessKey = strings.TrimSpace(request.FormValue("AccessKey"))
 	conf.SecretKey = strings.TrimSpace(request.FormValue("SecretKey"))
 	conf.BucketName = strings.TrimSpace(request.FormValue("BucketName"))
+	conf.Region = strings.TrimSpace(request.FormValue("Region"))
 
 	if conf.SecretKey != "" && conf.SecretKey != oldConf.SecretKey {
 		secretKey, err := util.EncryptByEncryptKey(conf.EncryptKey, conf.SecretKey)

--- a/web/writing.html
+++ b/web/writing.html
@@ -257,6 +257,14 @@
                 </div>
               </div>
 
+              <div class="form-group row">
+                <label for="Region" class="col-sm-2 col-form-label">Region</label>
+                <div class="col-sm-10">
+                  <input class="form-control" name="Region" id="Region" value="{{.Region}}" aria-describedby="Region_help">
+                  <small id="Region_help" class="form-text text-muted">可选，如果为空将自动从 Endpoint 推断区域，默认使用 cn-north-1</small>
+                </div>
+              </div>
+
             </div>
           </div>
 


### PR DESCRIPTION
适配 cloudflare R2 存储，使用 R2 存储只需 `Region` 设置为 `auto`

[cloudflare R2 区域官方文档](https://developers.cloudflare.com/r2/api/s3/api/#bucket-region)